### PR TITLE
Added errorprinting for the prebios files

### DIFF
--- a/src/main/resources/assets/cctweaks/lua/prebios-string.lua
+++ b/src/main/resources/assets/cctweaks/lua/prebios-string.lua
@@ -3,12 +3,28 @@ local function fail(msg)
 	term.setCursorBlink(false)
 	term.clear()
 	term.setCursorPos(1, 1)
-
+	local x, y = term.getSize()
 	-- Print some red text
 	if term.isColour() then term.setTextColour(16384) end
-	term.write(msg)
-
-	term.setCursorPos(1, 2)
+	
+	--Split the message into multiple parts if it's too long for the screen
+	local str = {}
+	local size
+	repeat
+		size = #msg
+		if size > x then
+			table.insert(str, string.sub(msg, 1, x))
+			msg = string.sub(msg, x+1)
+		else
+			table.insert(str, msg)
+			
+		end
+	until size <= x
+	for each, stri in ipairs(str) do
+		local cx, cy = term.getCursorPos()
+		term.write(stri)
+		term.setCursorPos(1, cy+1)
+	end
 	term.setTextColour(1)
 	term.write("Press any key to continue")
 
@@ -71,4 +87,12 @@ if native_getfenv then
 	end
 end
 
-return fun()
+-- Try to run the bios, print possible errors
+local _, ok, err = pcall(fun)
+if not _ then
+	fail(ok)
+elseif not ok then
+	fail(err)
+end
+
+return ok

--- a/src/main/resources/assets/cctweaks/lua/prebios.lua
+++ b/src/main/resources/assets/cctweaks/lua/prebios.lua
@@ -3,12 +3,29 @@ local function fail(msg)
 	term.setCursorBlink(false)
 	term.clear()
 	term.setCursorPos(1, 1)
-
+	local x, y = term.getSize()
 	-- Print some red text
 	if term.isColour() then term.setTextColour(16384) end
-	term.write(msg)
+	
+	--Split the message into multiple parts if it's too long for the screen
+	local str = {}
+	local size
+	repeat
+		size = #msg
+		if size > x then
+			table.insert(str, string.sub(msg, 1, x))
+			msg = string.sub(msg, x+1)
+		else
+			table.insert(str, msg)
+			
+		end
+	until size <= x
+	for each, stri in ipairs(str) do
+		local cx, cy = term.getCursorPos()
+		term.write(stri)
+		term.setCursorPos(1, cy+1)
+	end
 
-	term.setCursorPos(1, 2)
 	term.setTextColour(1)
 	term.write("Press any key to continue")
 
@@ -38,4 +55,14 @@ if not fun then
 	return
 end
 
-return fun()
+-- Try to run the bios, print possible errors
+
+local _, ok, err = pcall(fun)
+if not _ then
+	fail(ok)
+elseif not ok then
+	fail(err)
+end
+
+return ok
+


### PR DESCRIPTION
While testing out the mod I noticed that running a custom bios containing errors doesn't print out anything which left me with no idea on how to find the actual error so I changed some things in the prebios files.