### PR TITLE
Java 9 support 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ cache:
     - lib/
 jdk:
   - oraclejdk8
+  - oraclejdk9

--- a/src/main/java/org/squiddev/cctweaks/lua/launch/CCEmuRedux.java
+++ b/src/main/java/org/squiddev/cctweaks/lua/launch/CCEmuRedux.java
@@ -23,7 +23,7 @@ public class CCEmuRedux {
 		RewritingLoader loader = setupLoader();
 
 		if (width != null || height != null) {
-			loader.chain.add(new SizePatcher(
+			loader.chain().add(new SizePatcher(
 				width == null ? 51 : width,
 				height == null ? 19 : height
 			));
@@ -31,14 +31,14 @@ public class CCEmuRedux {
 
 		if (back != null) {
 			int val = back;
-			loader.chain.add(new ColorPatcher(
+			loader.chain().add(new ColorPatcher(
 				(val >> (8 * 2) & 255) / 255.0f,
 				(val >> (8 * 1) & 255) / 255.0f,
 				(val >> (8 * 0) & 255) / 255.0f
 			));
 		}
 
-		loader.chain.finalise();
+		loader.chain().finalise();
 		execute(loader, "com.xtansia.ccemu.desktop.DesktopLauncher", new String[0]);
 	}
 

--- a/src/main/java/org/squiddev/cctweaks/lua/launch/ClassLoaderHelpers.java
+++ b/src/main/java/org/squiddev/cctweaks/lua/launch/ClassLoaderHelpers.java
@@ -1,0 +1,138 @@
+package org.squiddev.cctweaks.lua.launch;
+
+import org.squiddev.cctweaks.lua.StreamHelpers;
+import org.squiddev.cctweaks.lua.TweaksLogger;
+import org.squiddev.patcher.transformer.TransformationChain;
+
+import java.io.*;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.security.CodeSigner;
+import java.security.CodeSource;
+import java.util.jar.JarFile;
+
+public final class ClassLoaderHelpers {
+	private ClassLoaderHelpers() {
+	}
+
+	/**
+	 * Add the default list of classloader exclusions to a rewriting loader
+	 *
+	 * @param loader The loader to register with.
+	 */
+	public static void setupExclusions(RewritingLoader loader) {
+		// Java/JDK internals
+		loader.addClassLoaderExclusion("com.sun.");
+		loader.addClassLoaderExclusion("java.");
+		loader.addClassLoaderExclusion("javax.");
+		loader.addClassLoaderExclusion("jdk.");
+		loader.addClassLoaderExclusion("org.w3c.dom.");
+		loader.addClassLoaderExclusion("org.xml.sax.");
+		loader.addClassLoaderExclusion("sun.");
+
+		// Common external libraries
+		loader.addClassLoaderExclusion("com.google.");
+		loader.addClassLoaderExclusion("org.objectweb.asm.");
+		loader.addClassLoaderExclusion("org.squiddev.patcher.");
+
+		// CCTweaks internals
+		loader.addClassLoaderExclusion("org.squiddev.cctweaks.lua.StreamHelpers");
+		loader.addClassLoaderExclusion("org.squiddev.cctweaks.lua.launch.");
+	}
+
+	/**
+	 * Setup the default transformation chain.
+	 *
+	 * @param loader The loader to register modifiers with.
+	 */
+	public static <T extends ClassLoader & RewritingLoader> void setupChain(T loader) throws Exception {
+		loader.loadClass("org.squiddev.cctweaks.lua.asm.Tweaks")
+			.getMethod("setup", TransformationChain.class)
+			.invoke(null, loader.chain());
+	}
+
+	/**
+	 * Sync {@link RewritingLoader#dump(boolean)} with the given config file.
+	 *
+	 * @param loader The loader to sync within
+	 */
+	public static <T extends ClassLoader & RewritingLoader> void syncDump(T loader) throws Exception {
+		loader.dump(
+			(Boolean) loader.loadClass("org.squiddev.cctweaks.lua.Config$Testing")
+				.getField("dumpAsm")
+				.get(null));
+	}
+
+	/**
+	 * Load config entries using the property loader
+	 *
+	 * @param loader The loader to load within
+	 */
+	public static void loadPropertyConfig(ClassLoader loader) throws Exception {
+		loader.loadClass("org.squiddev.cctweaks.lua.ConfigPropertyLoader")
+			.getMethod("init")
+			.invoke(null);
+	}
+
+	static CodeSource findSource(ClassLoader loader, String name) {
+		String fileName = name.replace('.', '/') + ".class";
+		URL url = loader.getResource(fileName);
+		if (url == null) return null;
+
+		CodeSigner[] signers = null;
+		if (name.lastIndexOf('.') > -1) {
+			try {
+				URLConnection connection = url.openConnection();
+				if (connection instanceof JarURLConnection) {
+					JarURLConnection jarConnection = (JarURLConnection) connection;
+					url = jarConnection.getJarFileURL();
+
+					JarFile jarFile = jarConnection.getJarFile();
+					if (jarFile != null && jarFile.getManifest() != null) {
+						signers = jarFile.getJarEntry(fileName).getCodeSigners();
+					}
+				}
+			} catch (IOException e) {
+				return null;
+			}
+		}
+
+		return new CodeSource(url, signers);
+	}
+
+	static byte[] getClassBytes(ClassLoader loader, String fileName) throws IOException {
+		InputStream classStream = null;
+		try {
+			classStream = loader.getResourceAsStream(fileName);
+			return classStream == null ? null : StreamHelpers.toByteArray(classStream);
+		} finally {
+			if (classStream != null) {
+				try {
+					classStream.close();
+				} catch (IOException ignored) {
+				}
+			}
+		}
+	}
+
+	static void dump(File file, byte[] bytes) {
+		File directory = file.getParentFile();
+		if (directory.exists() || directory.mkdirs()) {
+			try {
+				OutputStream stream = new FileOutputStream(file);
+				try {
+					stream.write(bytes);
+				} finally {
+					stream.close();
+				}
+			} catch (FileNotFoundException e) {
+				TweaksLogger.error("Cannot write " + file, e);
+			} catch (IOException e) {
+				TweaksLogger.error("Cannot write " + file, e);
+			}
+		} else {
+			TweaksLogger.warn("Cannot create folder for " + file);
+		}
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/lua/launch/DelegatingRewritingLoader.java
+++ b/src/main/java/org/squiddev/cctweaks/lua/launch/DelegatingRewritingLoader.java
@@ -1,0 +1,138 @@
+package org.squiddev.cctweaks.lua.launch;
+
+import org.squiddev.patcher.transformer.TransformationChain;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.SecureClassLoader;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This class loader wraps another class loader, transforming its classes.
+ *
+ * When loading a class, we first attempt to use the parent class loader. This is just
+ * the bootstrap loader in, so we will load all core-JDK classes as normal.
+ *
+ * Otherwise, we will determine whether a class is excluded by ({@link #addClassLoaderExclusion(String)}).
+ * If so, we'll pass this off to the delegate class loader again.
+ *
+ * If the class is not blacklisted then we use the delegate class loader to load the bytes,
+ * run the transformer on them, and load them into our own class loader.
+ */
+public class DelegatingRewritingLoader extends SecureClassLoader implements RewritingLoader {
+	private final WrapperClassLoader delegateWrapper;
+	private final ClassLoader delegate;
+	private final TransformationChain chain = new TransformationChain();
+	private final Set<String> classLoaderExceptions = new HashSet<String>();
+	private final File dumpFolder;
+	private boolean dumpAsm;
+
+	public DelegatingRewritingLoader(ClassLoader delegate) {
+		this(delegate, new File("asm/cctweaks"));
+	}
+
+	public DelegatingRewritingLoader(ClassLoader delegate, File dumpFolder) {
+		super(null);
+		this.delegate = delegate;
+		this.delegateWrapper = new WrapperClassLoader(delegate);
+		this.dumpFolder = dumpFolder;
+		ClassLoaderHelpers.setupExclusions(this);
+	}
+
+	@Nonnull
+	@Override
+	public TransformationChain chain() {
+		return chain;
+	}
+
+	@Override
+	public void addClassLoaderExclusion(String toExclude) {
+		classLoaderExceptions.add(toExclude);
+	}
+
+	@Override
+	public void dump(boolean on) {
+		dumpAsm = on;
+	}
+
+	@Override
+	public Class<?> findClass(final String name) throws ClassNotFoundException {
+		for (final String exception : classLoaderExceptions) {
+			if (name.startsWith(exception)) {
+				return delegate.loadClass(name);
+			}
+		}
+
+		try {
+			String fileName = name.replace('.', '/') + ".class";
+			CodeSource codeSource = ClassLoaderHelpers.findSource(delegate, name);
+
+			byte[] original = ClassLoaderHelpers.getClassBytes(delegate, fileName);
+			byte[] transformed = chain.transform(name, original);
+			if (transformed == null) throw new ClassNotFoundException(name);
+
+			if (original != transformed && dumpAsm) {
+				ClassLoaderHelpers.dump(new File(dumpFolder, fileName), transformed);
+			}
+
+			return defineClass(name, transformed, 0, transformed.length, codeSource);
+		} catch (ClassNotFoundException e) {
+			throw e;
+		} catch (RuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new ClassNotFoundException(name, e);
+		}
+	}
+
+	@Override
+	protected URL findResource(String name) {
+		URL url = super.findResource(name);
+		return url != null ? url : delegate.getResource(name);
+	}
+
+	@Override
+	protected Enumeration<URL> findResources(String name) throws IOException {
+		final Enumeration<URL> myRes = super.findResources(name);
+		final Enumeration<URL> delegateRes = delegate.getResources(name);
+
+		return new Enumeration<URL>() {
+			@Override
+			public boolean hasMoreElements() {
+				return myRes.hasMoreElements() || delegateRes.hasMoreElements();
+			}
+
+			@Override
+			public URL nextElement() {
+				return myRes.hasMoreElements() ? myRes.nextElement() : delegateRes.nextElement();
+			}
+		};
+	}
+
+	@Override
+	@Deprecated
+	protected Package getPackage(String name) {
+		Package pck = super.getPackage(name);
+		return pck != null ? pck : delegateWrapper.getPackage(name);
+	}
+
+	/**
+	 * A simple class loader which allows us to access several protected methods
+	 */
+	private static class WrapperClassLoader extends ClassLoader {
+		WrapperClassLoader(ClassLoader parent) {
+			super(parent);
+		}
+
+		@Override
+		@Deprecated
+		public Package getPackage(String name) {
+			return super.getPackage(name);
+		}
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/lua/launch/PriorityURLClassLoader.java
+++ b/src/main/java/org/squiddev/cctweaks/lua/launch/PriorityURLClassLoader.java
@@ -1,0 +1,75 @@
+package org.squiddev.cctweaks.lua.launch;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+
+/**
+ * A classloader which places a series of URLs *before* the parent class loader.
+ */
+public class PriorityURLClassLoader extends URLClassLoader {
+	private final WrapperClassLoader parent;
+
+	public PriorityURLClassLoader(URL[] urls, ClassLoader parent) {
+		super(urls, null);
+		this.parent = new WrapperClassLoader(parent);
+	}
+
+	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		synchronized (getClassLoadingLock(name)) {
+			// First, check if the class has already been loaded
+			Class<?> c = findLoadedClass(name);
+			if (c == null) {
+				try {
+					c = findClass(name);
+				} catch (ClassNotFoundException e) {
+					// ClassNotFoundException thrown if class not found
+					// from the this class loader
+				}
+
+				if (c == null) {
+					c = parent.loadClass(name, false);
+				}
+			}
+			if (resolve) {
+				resolveClass(c);
+			}
+			return c;
+		}
+	}
+
+	public URL getResource(String name) {
+		URL url = findResource(name);
+		if (url == null) url = parent.getResource(name);
+		return url;
+	}
+
+	public Enumeration<URL> getResources(String name) throws IOException {
+		final Enumeration<URL> mine = findResources(name);
+		final Enumeration<URL> parents = parent.getResources(name);
+
+		return new Enumeration<URL>() {
+			@Override
+			public boolean hasMoreElements() {
+				return mine.hasMoreElements() || parents.hasMoreElements();
+			}
+
+			@Override
+			public URL nextElement() {
+				return mine.hasMoreElements() ? mine.nextElement() : parents.nextElement();
+			}
+		};
+	}
+
+	private static class WrapperClassLoader extends ClassLoader {
+		WrapperClassLoader(ClassLoader parent) {
+			super(parent);
+		}
+
+		@Override
+		public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			return super.loadClass(name, resolve);
+		}
+	}
+}

--- a/src/main/java/org/squiddev/cctweaks/lua/launch/RewritingLoader.java
+++ b/src/main/java/org/squiddev/cctweaks/lua/launch/RewritingLoader.java
@@ -1,172 +1,35 @@
 package org.squiddev.cctweaks.lua.launch;
 
-import org.squiddev.cctweaks.lua.StreamHelpers;
-import org.squiddev.cctweaks.lua.TweaksLogger;
 import org.squiddev.patcher.transformer.TransformationChain;
 
-import java.io.*;
-import java.net.JarURLConnection;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.URLConnection;
-import java.security.CodeSigner;
-import java.security.CodeSource;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.jar.JarFile;
+import javax.annotation.Nonnull;
 
 /**
- * Loads classes, rewriting them
+ * An abstract class loader which will modify a set of classes
  */
-public class RewritingLoader extends URLClassLoader {
-	private ClassLoader parent = getClass().getClassLoader();
+public interface RewritingLoader {
+	/**
+	 * Get the transformation chain with which to modify classes.
+	 *
+	 * @return The transformation chain to use.
+	 */
+	@Nonnull
+	TransformationChain chain();
 
-	public final TransformationChain chain = new TransformationChain();
+	/**
+	 * Mark a class or package as excluded.
+	 *
+	 * Any class begining with {@code prefix} will be loaded using the
+	 * parent class loader instead.
+	 *
+	 * @param prefix The prefix to ignore.
+	 */
+	void addClassLoaderExclusion(String prefix);
 
-	private Set<String> classLoaderExceptions = new HashSet<String>();
-	private final File dumpFolder;
-	private boolean dumpAsm;
-
-	public RewritingLoader(URL[] urls) {
-		this(urls, new File("asm/cctweaks"));
-	}
-
-	public RewritingLoader(URL[] urls, File folder) {
-		super(urls, null);
-
-		dumpFolder = folder;
-
-		// classloader exclusions
-		addClassLoaderExclusion("java.");
-		addClassLoaderExclusion("sun.");
-		addClassLoaderExclusion("org.objectweb.asm.");
-		addClassLoaderExclusion("org.squiddev.patcher.");
-		addClassLoaderExclusion("com.google.");
-
-		addClassLoaderExclusion("org.squiddev.cctweaks.lua.StreamHelpers");
-		addClassLoaderExclusion("org.squiddev.cctweaks.lua.launch.");
-		addClassLoaderExclusion("org.squiddev.cctweaks.lua.asm.CustomChain");
-	}
-
-	@Override
-	public Class<?> findClass(final String name) throws ClassNotFoundException {
-		for (final String exception : classLoaderExceptions) {
-			if (name.startsWith(exception)) {
-				return parent.loadClass(name);
-			}
-		}
-
-		try {
-			final int lastDot = name.lastIndexOf('.');
-			final String fileName = name.replace('.', '/') + ".class";
-			URLConnection urlConnection = findCodeSourceConnectionFor(fileName);
-
-			CodeSigner[] signers = null;
-			if (lastDot > -1) {
-				if (urlConnection instanceof JarURLConnection) {
-					final JarURLConnection jarURLConnection = (JarURLConnection) urlConnection;
-					final JarFile jarFile = jarURLConnection.getJarFile();
-
-					if (jarFile != null && jarFile.getManifest() != null) {
-						signers = jarFile.getJarEntry(fileName).getCodeSigners();
-					}
-				}
-			}
-
-			byte[] original = getClassBytes(fileName);
-			byte[] transformed = chain.transform(name, original);
-			if (transformed == null) throw new ClassNotFoundException(name);
-			if (transformed != original) writeDump(fileName, transformed);
-
-			CodeSource codeSource = null;
-			if (urlConnection != null) {
-				URL url = urlConnection.getURL();
-				if (urlConnection instanceof JarURLConnection) {
-					url = ((JarURLConnection) urlConnection).getJarFileURL();
-				}
-
-				codeSource = new CodeSource(url, signers);
-			}
-
-			return defineClass(name, transformed, 0, transformed.length, codeSource);
-		} catch (ClassNotFoundException e) {
-			throw e;
-		} catch (Throwable e) {
-			throw new ClassNotFoundException(name, e);
-		}
-	}
-
-	private URLConnection findCodeSourceConnectionFor(final String name) {
-		final URL resource = findResource(name);
-		if (resource != null) {
-			try {
-				return resource.openConnection();
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
-		}
-
-		return null;
-	}
-
-	public void addClassLoaderExclusion(String toExclude) {
-		classLoaderExceptions.add(toExclude);
-	}
-
-	public void loadChain() throws Exception {
-		loadClass("org.squiddev.cctweaks.lua.asm.Tweaks")
-			.getMethod("setup", TransformationChain.class)
-			.invoke(null, chain);
-	}
-
-	public void loadConfig() throws Exception {
-		loadClass("org.squiddev.cctweaks.lua.ConfigPropertyLoader")
-			.getMethod("init")
-			.invoke(null);
-
-		dumpAsm = (Boolean) loadClass("org.squiddev.cctweaks.lua.Config$Testing")
-			.getField("dumpAsm")
-			.get(null);
-	}
-
-	private byte[] getClassBytes(String name) throws IOException {
-		InputStream classStream = null;
-		try {
-			final URL classResource = findResource(name);
-			if (classResource == null) return null;
-
-			classStream = classResource.openStream();
-			return StreamHelpers.toByteArray(classStream);
-		} finally {
-			if (classStream != null) {
-				try {
-					classStream.close();
-				} catch (IOException ignored) {
-				}
-			}
-		}
-	}
-
-	private void writeDump(String fileName, byte[] bytes) {
-		if (dumpAsm) {
-			File file = new File(dumpFolder, fileName);
-			File directory = file.getParentFile();
-			if (directory.exists() || directory.mkdirs()) {
-				try {
-					OutputStream stream = new FileOutputStream(file);
-					try {
-						stream.write(bytes);
-					} finally {
-						stream.close();
-					}
-				} catch (FileNotFoundException e) {
-					TweaksLogger.error("Cannot write " + file, e);
-				} catch (IOException e) {
-					TweaksLogger.error("Cannot write " + file, e);
-				}
-			} else {
-				TweaksLogger.warn("Cannot create folder for " + file);
-			}
-		}
-	}
+	/**
+	 * Determine whether modified class files should be dumped when loaded
+	 *
+	 * @param on Whether files should be dumped
+	 */
+	void dump(boolean on);
 }


### PR DESCRIPTION
Splits `RewritingLoader` into two separate loaders:

 - `PriorityURLClassLoader`: A parent-last class loader, where the array of URLs is checked before continuing to the parent. This is mostly used by tests to 
 - `DelegatingRewritingLoader`: A class loader which delegates to another class loader to fetch class data, modifies it and returns.

This should be sufficient to run on Java 8 and Java 9.